### PR TITLE
fix: chain auto-tag → release and drop stale packages.json ref

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: auto-tag-main
@@ -181,10 +182,17 @@ jobs:
           git reset --hard origin/main
 
       - name: Create and push tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NEXT_TAG="${{ steps.next.outputs.tag }}"
           git tag -a "$NEXT_TAG" -m "Release $NEXT_TAG"
           git push origin "$NEXT_TAG"
+
+          # A tag pushed with GITHUB_TOKEN does not trigger other workflows'
+          # `on: push: tags:` listeners (anti-recursion safeguard), so kick
+          # release.yml explicitly instead of relying on that push event.
+          gh workflow run release.yml --ref main -f tag="$NEXT_TAG"
 
       - name: Summary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,6 @@ jobs:
 
           # Copy key files
           cp Brewfile release-artifacts/
-          cp packages.json release-artifacts/
 
           # Create a tarball of the dotfiles (excluding .git and other artifacts)
           tar -czf release-artifacts/dotfiles-${{ steps.version.outputs.version }}.tar.gz \
@@ -125,7 +124,6 @@ jobs:
           generate_release_notes: ${{ steps.changelog.outputs.has_notes != 'true' }}
           files: |
             release-artifacts/Brewfile
-            release-artifacts/packages.json
             release-artifacts/dotfiles-${{ steps.version.outputs.version }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -139,7 +137,6 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Release Artifacts" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Brewfile" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ packages.json" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ dotfiles-${{ steps.version.outputs.version }}.tar.gz" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Release Notes" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2026-07-18
+### Fixed
+
+- Fixed `.github/workflows/release.yml` referencing a `packages.json` file removed months ago (commit `629fe27`) — its `Generate release artifacts` step failed on `cp: cannot stat 'packages.json'` for every release, including `2.1.0`, which is why that release's GitHub Release/artifacts had to be published manually
+- Fixed `.github/workflows/auto-tag.yml` tagging a release but never triggering `release.yml` — a tag pushed with the default `GITHUB_TOKEN` doesn't fire other workflows' `push: tags:` listeners (GitHub's anti-recursion safeguard for bot-authored events), so `auto-tag.yml` now explicitly dispatches `release.yml` via `gh workflow run` right after tagging
 
 ### Added
 


### PR DESCRIPTION
## Summary
- `release.yml` copied a `packages.json` that was deleted in `629fe27` ("feat: add NeoVim and relevant plugins") but never removed from the workflow — its `Generate release artifacts` step has been failing on every tag push since, including the just-created `2.1.0` (had to publish that release manually via `workflow_dispatch` after this fix).
- `auto-tag.yml` pushes the release tag using the default `GITHUB_TOKEN`. GitHub's anti-recursion safeguard means a `GITHUB_TOKEN`-authored push never triggers other workflows' `on: push: tags:` listeners, so `release.yml` was silently never firing automatically — `auto-tag.yml` now explicitly dispatches it (`gh workflow run release.yml --ref main -f tag=$NEXT_TAG`) right after tagging, which requires an added `actions: write` permission.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; ..."`)
- [x] `actionlint` — no new findings (pre-existing shellcheck style nits in `release.yml` untouched)
- [ ] Verify end-to-end on the next real release: PR merge → auto-tag.yml tags & opens/merges its changelog PR → dispatches release.yml → GitHub Release + artifacts published, with no manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)